### PR TITLE
Potential fix for code scanning alert no. 28: Log injection

### DIFF
--- a/apps/api/src/services/resume.service.ts
+++ b/apps/api/src/services/resume.service.ts
@@ -10,6 +10,13 @@ import mammoth from "mammoth";
 
 export class ResumeService {
   /**
+   * Sanitize text before logging to avoid log injection (e.g. newline injection).
+   */
+  private sanitizeForLog(input: string): string {
+    return input.replace(/[\r\n]/g, " ");
+  }
+
+  /**
    * Parse file content based on type
    */
   async parseFile(buffer: Buffer, mimetype: string): Promise<string> {
@@ -93,7 +100,9 @@ Return ONLY the JSON object, no markdown formatting or explanation.`;
     } catch (error) {
       console.error(
         "Failed to parse AI response:",
-        error instanceof Error ? error.message : "Unknown error",
+        error instanceof Error
+          ? this.sanitizeForLog(error.message)
+          : "Unknown error",
       );
       // Return default analysis if parsing fails
       return {
@@ -143,7 +152,9 @@ Return ONLY the JSON object, no markdown formatting or explanation.`;
       // Safe error logging to avoid log injection
       console.error(
         "Error processing resume:",
-        error instanceof Error ? error.message : "Unknown error",
+        error instanceof Error
+          ? this.sanitizeForLog(error.message)
+          : "Unknown error",
       );
       // The user can retry analysis later
       return resume;


### PR DESCRIPTION
Potential fix for [https://github.com/utsavjosh1/Postly/security/code-scanning/28](https://github.com/utsavjosh1/Postly/security/code-scanning/28)

In general, to fix log injection you must sanitize any user-controlled data before logging it. For plain-text logs, the key is to remove or neutralize newline (`\n`) and carriage return (`\r`) characters and, optionally, clearly delimit user input. Instead of logging `error.message` directly (which may contain user-controlled content), we can pass it through a small sanitizer that strips dangerous characters.

The best targeted fix here is: in `apps/api/src/services/resume.service.ts`, introduce a small `sanitizeForLog` helper function in `ResumeService` that removes `\n` and `\r` characters from a string. Then, in both `catch` blocks that currently do `error instanceof Error ? error.message : "Unknown error"`, wrap the message with this sanitizer, so only a cleaned, single-line message is logged. This avoids changing overall functionality: the same high-level error information is logged, but without allowing attackers to inject extra lines into the logs.

Concretely:
- Add a private method `sanitizeForLog(input: string): string` to `ResumeService` (e.g., near the top of the class), which uses `input.replace(/[\r\n]/g, " ")` or similar.
- In the `catch` block around `generateText` JSON parsing (lines 93–97), change the `console.error` message argument to call `this.sanitizeForLog(...)`.
- In the `catch` block in `processResume` (lines 142–147), do the same.
No new imports are required; `String.prototype.replace` is available by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
