### PR TITLE
Potential fix for code scanning alert no. 27: Useless assignment to local variable

### DIFF
--- a/apps/api/src/middleware/strict-rate-limit.ts
+++ b/apps/api/src/middleware/strict-rate-limit.ts
@@ -42,11 +42,12 @@ export const createStrictRateLimiter = (config: RateLimitConfig) => {
       const key = `${config.keyPrefix}:${userId}`;
 
       // Get dynamic max limit
-      let maxLimit = 3; // Default fallback
+      let maxLimit: number;
       if (typeof config.max === "function") {
-        maxLimit = await config.max(req);
+        const dynamicMax = await config.max(req);
+        maxLimit = dynamicMax ?? 3; // Default fallback if dynamicMax is null/undefined
       } else {
-        maxLimit = config.max;
+        maxLimit = (config.max as number) ?? 3; // Default fallback if config.max is undefined
       }
 
       // Get current count


### PR DESCRIPTION
Potential fix for [https://github.com/utsavjosh1/Postly/security/code-scanning/27](https://github.com/utsavjosh1/Postly/security/code-scanning/27)

In general, to fix a “useless assignment to local variable” you either remove the redundant initialization or change the control flow so that the initial value can actually be used as a meaningful default. Since the intention here is to have a sensible default max limit if none is provided, the best fix is to implement that default behavior explicitly rather than via an unused initializer.

Concretely, in `apps/api/src/middleware/strict-rate-limit.ts`, change the `maxLimit` initialization around lines 45–50. Instead of setting `let maxLimit = 3;` and always overwriting it, initialize `maxLimit` only when you actually know the effective limit. If `config.max` is a function, compute the limit with `await config.max(req)` and then fall back to `3` if it returns `null`/`undefined` (or some other falsy), otherwise use `config.max || 3` when it’s a number. This preserves existing behavior when `config.max` is properly set while finally making `3` a true fallback. No new imports or additional methods are required; only the logic for computing `maxLimit` needs to be updated in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
