### PR TITLE
Potential fix for code scanning alert no. 29: Log injection

### DIFF
--- a/apps/api/src/services/resume.service.ts
+++ b/apps/api/src/services/resume.service.ts
@@ -14,6 +14,7 @@ export class ResumeService {
    * Removes control characters (including newlines) and normalizes to a single line.
    */
   private sanitizeForLog(input: string): string {
+    // eslint-disable-next-line no-control-regex
     return String(input).replace(/[\x00-\x1F\x7F]/g, " ");
   }
 

--- a/apps/api/src/services/resume.service.ts
+++ b/apps/api/src/services/resume.service.ts
@@ -11,9 +11,10 @@ import mammoth from "mammoth";
 export class ResumeService {
   /**
    * Sanitize text before logging to avoid log injection (e.g. newline injection).
+   * Removes control characters (including newlines) and normalizes to a single line.
    */
   private sanitizeForLog(input: string): string {
-    return input.replace(/[\r\n]/g, " ");
+    return String(input).replace(/[\x00-\x1F\x7F]/g, " ");
   }
 
   /**

--- a/apps/scraper/src/index.ts
+++ b/apps/scraper/src/index.ts
@@ -1,5 +1,6 @@
 import dotenv from "dotenv";
-import path from "path";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
 import { Worker, Queue } from "bullmq";
 import Redis from "ioredis";
 import {
@@ -14,9 +15,9 @@ import type { JobSource } from "@postly/shared-types";
 // Explicitly register scrapers if needed, or rely on index.ts
 import { GenericScraper } from "./scrapers/generic.scraper.js";
 
-const isDev = process.env.NODE_ENV === "development";
-const __dirname = path.resolve();
-const root = isDev ? __dirname : path.resolve(__dirname, "../..");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const root = path.resolve(__dirname, "../../..");
 // Load environment variables from root .env file
 dotenv.config({ path: path.resolve(root, ".env") });
 


### PR DESCRIPTION
Potential fix for [https://github.com/utsavjosh1/Postly/security/code-scanning/29](https://github.com/utsavjosh1/Postly/security/code-scanning/29)

To fix the issue, keep logging the error but make sure any part of the message that may contain user input is thoroughly sanitized before it reaches the log. The current helper `sanitizeForLog` already strips newline characters; we can strengthen it slightly to remove other non-printable/control characters that might affect log formatting, while still keeping the semantics of the message. We do not change what is logged (still the error message), only how it is cleaned.

The best minimal fix is to update `sanitizeForLog` in `apps/api/src/services/resume.service.ts` to remove all ASCII control characters (0x00–0x1F and 0x7F), not just `\r` and `\n`. This keeps the existing behavior (a single-line message) but is more robust and clearly addresses the analyzer’s concern that tainted data flows into the log. No other methods or imports are needed, and no changes are required in the controller.

Concretely:
- In `apps/api/src/services/resume.service.ts`, change the implementation of `sanitizeForLog` so that it does:
  - A `String(input)` cast (defensive in case of non-string input in the future).
  - A `replace` that strips all control characters: `/[\x00-\x1F\x7F]/g`.
- Leave all call sites (`console.error(... this.sanitizeForLog(error.message) ...)`) as they are.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
