### PR TITLE
Potential fix for code scanning alert no. 77: Missing rate limiting

### DIFF
--- a/apps/api/src/routes/discord.routes.ts
+++ b/apps/api/src/routes/discord.routes.ts
@@ -1,10 +1,19 @@
 import { Router } from "express";
+import rateLimit from "express-rate-limit";
 import { authenticateToken } from "../middleware/auth.js";
 import { DiscordController } from "../controllers/discord.controller.js";
 
 const router = Router();
 const discordController = new DiscordController();
 
+const discordRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+router.use(discordRateLimiter);
 router.use(authenticateToken);
 
 router.get("/callback", discordController.handleCallback);


### PR DESCRIPTION
Potential fix for [https://github.com/utsavjosh1/Postly/security/code-scanning/77](https://github.com/utsavjosh1/Postly/security/code-scanning/77)

Add an Express rate-limiting middleware and apply it before `authenticateToken` so abusive traffic is throttled before auth/controller execution.

Best single fix in this file:
1. Import `express-rate-limit`.
2. Define a limiter instance (for example, 100 requests per 15 minutes per IP).
3. Register the limiter on the router with `router.use(...)` before `router.use(authenticateToken)`.

This preserves existing route behavior while adding a protective throttle for all Discord routes in `apps/api/src/routes/discord.routes.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
