### PR TITLE
Potential fix for code scanning alert no. 58: CORS misconfiguration for credentials transfer

### DIFF
--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -21,17 +21,21 @@ export function errorHandler(
 
   // Ensure CORS headers are present even in error responses, but ONLY for trusted origins
   const origin = _req.headers.origin;
-  if (origin) {
+  if (typeof origin === "string" && origin.length > 0) {
     const allowedOrigins = WEB_URL
       ? WEB_URL.split(",")
           .map((o) => o.trim().replace(/\/$/, ""))
           .filter(Boolean)
       : [];
 
-    const normalizedOrigin = origin.replace(/\/$/, "");
+    const normalizedOrigin = origin.trim().replace(/\/$/, "");
+    const matchedOrigin =
+      normalizedOrigin !== "null"
+        ? allowedOrigins.find((o) => o === normalizedOrigin)
+        : undefined;
 
-    if (allowedOrigins.includes(normalizedOrigin)) {
-      res.setHeader("Access-Control-Allow-Origin", origin as string);
+    if (matchedOrigin) {
+      res.setHeader("Access-Control-Allow-Origin", matchedOrigin);
       res.setHeader("Access-Control-Allow-Credentials", "true");
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/utsavjosh1/Postly/security/code-scanning/58](https://github.com/utsavjosh1/Postly/security/code-scanning/58)

To fix this safely, keep the allowlist logic but stop writing the raw request header back to `Access-Control-Allow-Origin`. Instead:

- Normalize and validate the request origin.
- Explicitly reject `"null"`.
- Find an exact match in the normalized trusted origins list.
- Set `Access-Control-Allow-Origin` to the **trusted matched value** (server-side canonical value), not `origin`.

In `apps/api/src/middleware/error-handler.ts`, update the CORS block around lines 23–36:
- Build `allowedOrigins` as normalized values.
- Ensure `normalizedOrigin !== "null"`.
- Use `const matchedOrigin = allowedOrigins.find((o) => o === normalizedOrigin);`
- If matched, set header with `matchedOrigin` instead of `origin as string`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
